### PR TITLE
fixed travis skipped doc generation on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
     # Deployment
     - stage: deploy
       python: 3.7
-      script: skip
       if: branch = master
       deploy:
         # Upload documentation to github pages

--- a/uberdot/constants.py
+++ b/uberdot/constants.py
@@ -33,7 +33,7 @@ from uberdot.utils import find_files
 from uberdot.utils import get_user_env_var
 from uberdot.utils import normpath
 
-VERSION = "1.13.0_4"
+VERSION = "1.13.1_4"
 
 """Version numbers, seperated by underscore.
 


### PR DESCRIPTION
In #64 I fixed that the docs couldn't cause the build to fail by moving the generation of the docs to the script phase. 

This caused a problem with deploying since the deploy job skipped the script phase.